### PR TITLE
Add Private Channel Rule for ChannelInterceptor

### DIFF
--- a/rules/ChannelAccept.js
+++ b/rules/ChannelAccept.js
@@ -1,4 +1,4 @@
-// only channels > 0.75 Msat
+// only channels > 0.75 Mio sats
 ChannelAccept.Event.FundingAmt >= 750000 && 
 // nodes with high 1ML availability score
 ChannelAccept.OneMl.Noderank.Availability > 100 &&
@@ -17,4 +17,13 @@ ChannelAccept.OneMl.Noderank.Age < 10000 &&
     ChannelAccept.Amboss.GraphInfo.Metrics.CapacityRank < 1000 ||
     // or nodes with high-ranking channel count
     ChannelAccept.Amboss.GraphInfo.Metrics.ChannelsRank < 1000
-)
+)&&
+(
+    // Only allow private channels which are smaller than 10 mio sats
+    (ChannelAccept.Event.ChannelFlags & 1) == 0 && 
+    ChannelAccept.Event.FundingAmt <= 10000000 ||
+    // allow all public channels
+    (ChannelAccept.Event.ChannelFlags & 1) == 1
+) 
+
+


### PR DESCRIPTION
This PR adds an example rule for accepting private channels only up to a certain size. It checks the least significant bit of `ChannelAccept.Event.ChannelFlags` which encodes this information (`(ChannelAccept.Event.ChannelFlags & 1) == 0` for private channels and `1` for public channels).