### PR TITLE
Add passthrogh mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Edit `config.yaml.example` and rename to `config.yaml`.
 
 # Rules
 
+## Passthrough
+
+The `passthrough` option is a mode for both `ChannelMode` and `ForwardMode` in the `config.yaml` file. When set to `passthrough`, electronwall will not apply any allowlist, denylist, or programmable rules to channel open requests or HTLC forwards. Instead, it will simply pass through all requests without any checks.
+
 ## Allowlist and denylist
 
 Allowlist and denylist rules are set in `config.yaml` under the appropriate keys. See the [example](config.yaml.example) config. 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,9 +12,10 @@ debug: true
 
 # ----- Channel openings -----
 
-# Mode can either be "denylist" or "allowlist"
-# Only one mode can be used at a time, the other list is ignored.
-channel-mode: "denylist" 
+# Mode can be "denylist", "allowlist", or "passthrough". Only one mode can be active.
+# If "denylist" is active, "allowlist" is ignored, and vice versa.
+# "passthrough" passes all requests through without checks, ignoring both lists.
+channel-mode: "denylist"
 
 # This error message will be sent to the other party upon a reject
 channel-reject-message: "Contact me at user@email.com"
@@ -29,8 +30,9 @@ channel-denylist:
 
 # ----- HTLC forwarding -----
 
-# Mode can either be "denylist" or "allowlist"
-# Only one mode can be used at a time, the other list is ignored.
+# Mode can be "denylist", "allowlist", or "passthrough". Only one mode can be active.
+# If "denylist" is active, "allowlist" is ignored, and vice versa.
+# "passthrough" passes all requests through without checks, ignoring both lists.
 forward-mode: "denylist"
 
 # List of channel IDs to allowlist or denylist

--- a/config/config.go
+++ b/config/config.go
@@ -61,8 +61,8 @@ func checkConfig() {
 	if len(Configuration.ChannelMode) == 0 {
 		Configuration.ChannelMode = "denylist"
 	}
-	if Configuration.ChannelMode != "allowlist" && Configuration.ChannelMode != "denylist" {
-		panic(fmt.Errorf("channel mode must be either allowlist or denylist"))
+	if Configuration.ChannelMode != "allowlist" && Configuration.ChannelMode != "denylist" && Configuration.ChannelMode != "passthrough" {
+		panic(fmt.Errorf("channel mode must be either allowlist, denylist or passthrough"))
 	}
 
 	log.Infof("Channel acceptor running in %s mode", Configuration.ChannelMode)
@@ -70,8 +70,8 @@ func checkConfig() {
 	if len(Configuration.ForwardMode) == 0 {
 		Configuration.ForwardMode = "denylist"
 	}
-	if Configuration.ForwardMode != "allowlist" && Configuration.ForwardMode != "denylist" {
-		panic(fmt.Errorf("channel mode must be either allowlist or denylist"))
+	if Configuration.ForwardMode != "allowlist" && Configuration.ForwardMode != "denylist" && Configuration.ForwardMode != "passthrough" {
+		panic(fmt.Errorf("forward mode must be either allowlist, denylist or passthrough"))
 	}
 
 	log.Infof("HTLC forwarder running in %s mode", Configuration.ForwardMode)

--- a/main.go
+++ b/main.go
@@ -108,10 +108,14 @@ func main() {
 		wg.Add(2)
 
 		// channel acceptor
-		app.DispatchChannelAcceptor(ctx)
+		if config.Configuration.ChannelMode != "passthrough" {
+			app.DispatchChannelAcceptor(ctx)
+		}
 
 		// htlc acceptor
-		app.DispatchHTLCAcceptor(ctx)
+		if config.Configuration.ForwardMode != "passthrough" {
+			app.DispatchHTLCAcceptor(ctx)
+		}
 
 		wg.Wait()
 		log.Info("All routines stopped. Waiting for new connection.")


### PR DESCRIPTION
This pull request introduces a new `passthrough` mode for both `ChannelMode` and `ForwardMode` in the `config.yaml` file. The `passthrough` mode bypasses any allowlist, denylist, or programmable rules to channel open requests or HTLC forwards. 

The main changes are:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41-R44): Added a new section to explain the `passthrough` mode in the `config.yaml` file.

Updates to `config.yaml.example`:

* Updated the comments to reflect the addition of the `passthrough` mode in both `channel-mode` and `forward-mode`. [[1]](diffhunk://#diff-8820e266c757e766e9a345e6aa55bcd237f1795744ed124b49c5c50434dcdbecL15-R17) [[2]](diffhunk://#diff-8820e266c757e766e9a345e6aa55bcd237f1795744ed124b49c5c50434dcdbecL32-R35)

Changes in the Go files:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L64-R74): Updated the `checkConfig` function to validate the `passthrough` mode for both `ChannelMode` and `ForwardMode`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R111-R118): Modified the `main` function to bypass the dispatch of `ChannelAcceptor` and `HTLCAcceptor` if the mode is set to `passthrough`.

Fixes https://github.com/callebtc/electronwall/issues/18